### PR TITLE
Use 'aragon apm' instead of 'apm' alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "npm run build:app && npm run build:script",
     "start": "aragon run",
     "deploy": "aragon deploy",
-    "publish": "apm publish"
+    "publish": "aragon apm publish"
   },
   "keywords": [],
   "license": "MIT"


### PR DESCRIPTION
Update boilerplate given the alias is being removed: aragon/aragon-cli#183